### PR TITLE
DevOps: move project containers to github package using git workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Build and push anyway Docker image
       uses: docker/build-push-action@v1.1.1
       with:
-        name: ${{ env.DOCKER_REPOSITORY_ANYWAY_REPORTS }}
+        name: ${{ env.DOCKER_REPOSITORY_ANYWAY_REPORTS }}/imagename
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
         registry: docker.pkg.github.com

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ move-to-github-packages ]
 env:
-  DOCKER_REPOSITORY_ANYWAY_REPORTS: "omertalmi5/anyway-reports"
+  DOCKER_REPOSITORY_ANYWAY_REPORTS: "${{ github.repository }}/anyway-reports"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
 env:
   DOCKER_REPOSITORY_ANYWAY_REPORTS: "${{ github.repository }}/anyway-reports"
+  REGISTRY_URL: "docker.pkg.github.com"
 
 jobs:
   Build-anyway-reports:
@@ -17,7 +18,7 @@ jobs:
         name: ${{ env.DOCKER_REPOSITORY_ANYWAY_REPORTS }}
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
-        registry: docker.pkg.github.com
+        registry: ${{ env.REGISTRY_URL }}
         repository: ${{ env.DOCKER_REPOSITORY_ANYWAY_REPORTS }}
         tag_with_ref: true
         tag_with_sha: true
@@ -30,7 +31,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - env:
-        DOCKER_REPOSITORY_ANYWAY_REPORTS: ${{ env.SERVER }}/${{ env.DOCKER_REPOSITORY_ANYWAY_REPORTS }}
+        DOCKER_REPOSITORY_ANYWAY_REPORTS: ${{ env.REGISTRY_URL }}/${{ env.DOCKER_REPOSITORY_ANYWAY_REPORTS }}
         HASADNA_K8S_DEPLOY_KEY: ${{ secrets.HASADNA_K8S_DEPLOY_KEY }}
       run: |
         SHA_TAG=sha-`git rev-parse --short $GITHUB_SHA` &&\

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - env:
-        DOCKER_REPOSITORY_ANYWAY_REPORTS: ${{ env.DOCKER_REPOSITORY_ANYWAY_REPORTS }}
+        DOCKER_REPOSITORY_ANYWAY_REPORTS: ${{ env.SERVER }}/${{ env.DOCKER_REPOSITORY_ANYWAY_REPORTS }}
         HASADNA_K8S_DEPLOY_KEY: ${{ secrets.HASADNA_K8S_DEPLOY_KEY }}
       run: |
         SHA_TAG=sha-`git rev-parse --short $GITHUB_SHA` &&\

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Build Docker
 
 on:
   push:
-    branches: [ master ]
+    branches: [ move-to-github-packages ]
 env:
   DOCKER_REPOSITORY_ANYWAY_REPORTS: "${{ github.repository }}/anyway-reports"
   REGISTRY_URL: "docker.pkg.github.com"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ move-to-github-packages ]
 env:
-  DOCKER_REPOSITORY_ANYWAY_REPORTS: "anywayteam/anyway-reports"  
+  DOCKER_REPOSITORY_ANYWAY_REPORTS: "omertalmi5/anyway-reports"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -16,7 +16,7 @@ jobs:
     - name: Build and push anyway Docker image
       uses: docker/build-push-action@v1.1.1
       with:
-        name: ${{ env.DOCKER_REPOSITORY_ANYWAY_REPORTS }}/imagename
+        name: ${{ env.DOCKER_REPOSITORY_ANYWAY_REPORTS }}
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
         registry: docker.pkg.github.com

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: Build Docker
-
+ 
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Build Docker
 
 on:
   push:
-    branches: [ move-to-github-packages ]
+    branches: [ master ]
 env:
   DOCKER_REPOSITORY_ANYWAY_REPORTS: "${{ github.repository }}/anyway-reports"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Build Docker
 
 on:
   push:
-    branches: [ move-to-github-packages ]
+    branches: [ master ]
 env:
   DOCKER_REPOSITORY_ANYWAY_REPORTS: "${{ github.repository }}/anyway-reports"
   REGISTRY_URL: "docker.pkg.github.com"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,10 +6,8 @@ on:
 env:
   DOCKER_REPOSITORY_ANYWAY_REPORTS: "${{ github.repository }}/anyway-reports"
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   Build-anyway-reports:
-    #if: github.repository == 'hasadna/anyway-reports'
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
@@ -26,7 +24,6 @@ jobs:
         cache_from: ${{ env.DOCKER_REPOSITORY_ANYWAY_REPORTS }}:master
   
   deploy:
-    #if: github.repository == 'hasadna/anyway' && github.ref == 'refs/heads/master'
     needs:
       - Build-anyway-reports
     runs-on: ubuntu-18.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,5 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Build Docker
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   push:
     branches: [ master ]
@@ -18,14 +14,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build and push anyway Docker image
-      uses: docker/build-push-action@v1.0.1
+      uses: docker/build-push-action@v1.1.1
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: ${{ env.DOCKER_REPOSITORY_ANYWAY_REPORTS }}
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        registry: docker.pkg.github.com
+        repository: ${{ env.DOCKER_REPOSITORY_ANYWAY }}
         tag_with_ref: true
         tag_with_sha: true
-        cache_from: ${{ env.DOCKER_REPOSITORY_ANYWAY_REPORTS }}:master 
+        cache_from: ${{ env.DOCKER_REPOSITORY_ANYWAY_REPORTS }}:master
   
   deploy:
     #if: github.repository == 'hasadna/anyway' && github.ref == 'refs/heads/master'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,11 @@ jobs:
     - name: Build and push anyway Docker image
       uses: docker/build-push-action@v1.1.1
       with:
+        name: ${{ env.DOCKER_REPOSITORY_ANYWAY_REPORTS }}
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
         registry: docker.pkg.github.com
-        repository: ${{ env.DOCKER_REPOSITORY_ANYWAY }}
+        repository: ${{ env.DOCKER_REPOSITORY_ANYWAY_REPORTS }}
         tag_with_ref: true
         tag_with_sha: true
         cache_from: ${{ env.DOCKER_REPOSITORY_ANYWAY_REPORTS }}:master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,8 @@
 name: Build Docker
- 
+
 on:
   push:
-    branches: [ master ]
+    branches: [ move-to-github-packages ]
 env:
   DOCKER_REPOSITORY_ANYWAY_REPORTS: "anywayteam/anyway-reports"  
 


### PR DESCRIPTION
According to the last news from the docker hub we moving all containers of all projects to store the project's images on GitHub, using github packages.

This PR change and refactor the git workflow CI that already exists.

```
change: main file - push image to GitHub package.
```

I checked only the building and pushing of the image.
**I don't know how to check that the deploying is correct.**