### PR TITLE
change deploy hasadna-k8s values file path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,10 +45,9 @@ jobs:
           export GIT_SSH_COMMAND="ssh -i `pwd`/hasadna_k8s_deploy_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" &&\
           git clone git@github.com:hasadna/hasadna-k8s.git &&\
           cd hasadna-k8s &&\
-          python update_yaml.py '{"anyway":{"anywayReportsImage":"'${ANYWAY_REPORTS_IMAGE}'"}}'  ./values.auto-updated.yaml &&\
-          cat  ./values.auto-updated.yaml
+          python update_yaml.py '{"anywayReportsImage":"'${ANYWAY_REPORTS_IMAGE}'"}' apps/anyway/values-anyway-auto-updated.yaml &&\
           git config --global user.name "Anyway CI" &&\
           git config --global user.email "anyway-ci@localhost" &&\
-          git add ./values.auto-updated.yaml && git commit -m "automatic update of anyway-report docker image" &&\
+          git add apps/anyway/values-anyway-auto-updated.yaml && git commit -m "automatic update of anyway-report docker image" &&\
           git push origin master
         fi          


### PR DESCRIPTION
this change is required because we are changing the way deployment works in hasadna-k8s

we are migrating to use ArgoCD, see https://github.com/hasadna/hasadna-k8s/blob/master/docs/argocd.md